### PR TITLE
[UEPR-17] Changed library name

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,6 +12,13 @@ const common = {
 
 const nodeBuilder = new ScratchWebpackConfigBuilder(common)
     .setTarget('node')
+    .merge({
+        output: {
+            library: {
+                name: 'VirtualMachine'
+            }
+        }
+    })
     .addModuleRule({
         test: /\.mp3$/,
         type: 'asset'
@@ -23,6 +30,11 @@ const webBuilder = new ScratchWebpackConfigBuilder(common)
         resolve: {
             fallback: {
                 Buffer: require.resolve('buffer/')
+            }
+        },
+        output: {
+            library: {
+                name: 'VirtualMachine'
             }
         }
     })
@@ -56,7 +68,10 @@ const playgroundBuilder = webBuilder.clone()
             'video-sensing-extension-debug': './src/extensions/scratch3_video_sensing/debug'
         },
         output: {
-            path: path.resolve(__dirname, 'playground')
+            path: path.resolve(__dirname, 'playground'),
+            library: {
+                name: 'VirtualMachine'
+            }
         }
     })
     .addModuleRule({

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -92,7 +92,7 @@ const playgroundBuilder = webBuilder.clone()
         }
     })
     .addModuleRule({
-        test: require.resolve('scratch-render/src/index.js'),
+        test: require.resolve('scratch-render'),
         loader: 'expose-loader',
         options: {
             exposes: 'ScratchRender'


### PR DESCRIPTION
### Jira Ticket
[UEPR-17](https://scratchfoundation.atlassian.net/browse/UEPR-17)

### Resolves

The introduction of `exports` field in [scratch-render's](https://github.com/scratchfoundation/scratch-render/pull/1265) `package.json` required changes to the path passed in the webpack configuration. Also changed library name as other applications depend on it.

### Test Coverage

- Build works, tests continue to pass


[UEPR-17]: https://scratchfoundation.atlassian.net/browse/UEPR-17?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ